### PR TITLE
PR - Fetching version information from package.json

### DIFF
--- a/src/js/modules/core/Config.js
+++ b/src/js/modules/core/Config.js
@@ -1,5 +1,7 @@
+import { version } from '/package.json';
+
 const Config = {
-    version: '1.0.0-beta2',
+    version: version,
     baseProjection: 'EPSG:3857',
     wgs84Projection: 'EPSG:4326',
     animationDuration: 350


### PR DESCRIPTION
Removed hardcoded version information from the About tool. Fetching it from package.json instead.